### PR TITLE
feat(PSS): Add PSS labels to NS

### DIFF
--- a/charts/iam-manager/Chart.yaml
+++ b/charts/iam-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: iam-manager
 description: Installs the Keiko Project IAM Manager
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: v0.0.6
 sources:
   - https://github.com/keikoproj/iam-manager

--- a/charts/iam-manager/README.md
+++ b/charts/iam-manager/README.md
@@ -1,6 +1,6 @@
 # iam-manager
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.6](https://img.shields.io/badge/AppVersion-v0.0.6-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.6](https://img.shields.io/badge/AppVersion-v0.0.6-informational?style=flat-square)
 
 Installs the Keiko Project IAM Manager
 

--- a/charts/iam-manager/templates/namespace.yaml
+++ b/charts/iam-manager/templates/namespace.yaml
@@ -3,4 +3,6 @@ kind: Namespace
 metadata:
   labels:
     {{- include "iam-manager.labels" . | nindent 4 }}
+    pod-security.kubernetes.io/enforced: baseline
+    pod-security.kubernetes.io/warn: baseline
   name: {{ .Values.namespace }}


### PR DESCRIPTION
Adds PSS (Pod Security Standard) labels to the namespace.

```
$ k label --dry-run=server --overwrite ns iam-manager-system pod-security.kubernetes.io/enforce=restricted
Warning: existing pods in namespace "iam-manager-system" violate the new PodSecurity enforce level "restricted:latest"
Warning: iam-manager-012345678-01234: unrestricted capabilities, runAsNonRoot != true
namespace/iam-manager-system labeled (server dry run)
$ k label --dry-run=server --overwrite ns iam-manager-system pod-security.kubernetes.io/enforce=baseline
namespace/iam-manager-system labeled (server dry run)
```